### PR TITLE
Tests and NaN-skip functionality for DecSeqDetectZ()

### DIFF
--- a/code-matlab/shared/proc/Decoding/DecSeqDetectZ.m
+++ b/code-matlab/shared/proc/Decoding/DecSeqDetectZ.m
@@ -23,7 +23,11 @@ function [seq_iv,decoded_z] = DecSeqDetectZ(cfg_in,P)
 
 cfg_def = [];
 cfg_def.maxJump = 20; % number of bins decoded Z can jump without breaking sequence
-cfg_def.minLength = 3;
+cfg_def.minLength = 3; % number of time bins without break for sequence
+cfg_def.nMaxNanSkipSequential = 1; % number of consecutive NaN bins that can be skipped 
+% before sequence is terminated
+cfg_def.nMaxNanSkipTotal = Inf; % if non-integer, maximum fraction of sequence length 
+% that is NaN acceptable for sequence to be included; if integer, maximum NaN count
 
 cfg = ProcessConfig(cfg_def,cfg_in);
 
@@ -43,30 +47,89 @@ this_start_idx = [];
 prev_val = -100;
 
 tstart = []; tend = [];
+current_skip = 0; total_skip = 0;
 for iT = 1:length(decoded_z.data)
     
-    this_jump = abs(decoded_z.data(iT)-prev_val);
+    sequence_broken = 0;
+       
+    if isnan(decoded_z.data(iT))
     
-    if this_jump < cfg.maxJump
-        
-        % check if sequence started
-        if isempty(this_start_idx)
-           this_start_idx = iT-1; 
+        % NaNs cannot start a sequence, but if sequence already started, may tolerate
+        if ~isempty(this_start_idx)
+            current_skip = current_skip + 1;
+            total_skip = total_skip + 1;
+            if current_skip > cfg.nMaxNanSkipSequential
+                sequence_broken = 1;
+            end
         end
-        
-    else % sequence broken
-    
-        % check if long enough
-        if iT - this_start_idx >= cfg.minLength % criterion met
-            nDetected = nDetected + 1;
-            tstart(nDetected) = decoded_z.tvec(this_start_idx);
-            tend(nDetected) = decoded_z.tvec(iT-1);
-        end
-        this_start_idx = [];
-        
+           
     end
     
-    prev_val = decoded_z.data(iT);
+    this_jump = abs(decoded_z.data(iT)-prev_val);
+        
+    if this_jump <= cfg.maxJump % good sample 
+        
+        % check if sequence started; if not, start it
+        if isempty(this_start_idx)
+           this_start_idx = iT-1;
+           total_skip = 0;
+        end
+        
+        % also reset skip counter
+        current_skip = 0;
+    
+    end
+    
+    if ~isnan(decoded_z.data(iT)) & this_jump > cfg.maxJump
+       sequence_broken = 1; 
+    end
+        
+    if sequence_broken | (iT == length(decoded_z.data)) % sequence broken, or end of data
+    
+        % check if long enough
+        this_length = iT - this_start_idx;
+        if this_length >= cfg.minLength % length criterion met
+            sequence_pass = 1;
+            
+            % test for total NaNs here
+            if mod(cfg.nMaxNanSkipTotal,1) == 0 % integer, parameter is a count
+                if total_skip > cfg.nMaxNanSkipTotal
+                   sequence_pass = 0; 
+                end
+            else % non-integer, parameter is a fraction of length
+                if total_skip > floor(this_length.*cfg.nMaxNanSkipTotal)
+                    sequence_pass = 0;
+                end
+            end
+            
+            if sequence_pass
+                % if pass, store for output
+                nDetected = nDetected + 1;
+                tstart(nDetected) = decoded_z.tvec(this_start_idx);
+                
+                if current_skip > 0
+                    nBack = current_skip - 1; % sequence can't end in NaN
+                else
+                    nBack = 0;
+                end
+                
+                % annoying edge case if last sample was part of a sequence
+                if (iT == length(decoded_z.data)) & ~sequence_broken
+                    lastSampleAdjustment = 1;
+                else
+                    lastSampleAdjustment = 0;
+                end
+                
+                tend(nDetected) = decoded_z.tvec(iT-1-nBack+lastSampleAdjustment);
+            end
+        end % of sufficient length
+        this_start_idx = [];
+      
+    end % of sequence_broken
+    
+    if ~isnan(decoded_z.data(iT))
+        prev_val = decoded_z.data(iT);
+    end
     
 end
 

--- a/code-matlab/shared/tests/TEST_DecSeqDetectZ.m
+++ b/code-matlab/shared/tests/TEST_DecSeqDetectZ.m
@@ -32,6 +32,60 @@ seq_iv = DecSeqDetectZ(cfg,P);
 
 verifyEqual(testCase,seq_iv.tstart,expected_iv.tstart,'Single sequence start time incorrect');
 verifyEqual(testCase,seq_iv.tend,expected_iv.tend,'Single sequence end time incorrect');
+
+% single NaN case - no skip
+P.data(:,6) = NaN;
+expected_iv.tstart = [1; 7]; expected_iv.tend = [5; 11];
+
+cfg = []; seq_iv = DecSeqDetectZ(cfg,P);
+
+verifyEqual(testCase,seq_iv.tstart,expected_iv.tstart,'Single noskip NaN sequence start times incorrect');
+verifyEqual(testCase,seq_iv.tend,expected_iv.tend,'Single noskip NaN sequence end times incorrect');
+
+% skip
+expected_iv.tstart = 1; expected_iv.tend = 11;
+
+cfg = []; cfg.nMaxNanSkipSequential = 1; seq_iv = DecSeqDetectZ(cfg,P);
+
+verifyEqual(testCase,seq_iv.tstart,expected_iv.tstart,'Single skip NaN sequence start time incorrect');
+verifyEqual(testCase,seq_iv.tend,expected_iv.tend,'Single skip NaN sequence end time incorrect');
+
+% single NaN case followed by too big jump
+P.data(:,7) = 0; P.data(50,7) = 1; 
+
+expected_iv.tstart = [1; 8]; expected_iv.tend = [5; 11];
+
+cfg = []; cfg.nMaxNanSkipSequential = 1;  seq_iv = DecSeqDetectZ(cfg,P);
+
+verifyEqual(testCase,seq_iv.tstart,expected_iv.tstart,'Single skipjump NaN sequence start times incorrect');
+verifyEqual(testCase,seq_iv.tend,expected_iv.tend,'Single skipjump NaN sequence end times incorrect');
+
+% double NaN case
+P.data(:,7) = NaN;
+expected_iv.tstart = [1; 8]; expected_iv.tend = [5; 11];
+
+cfg = []; cfg.nMaxNanSkipSequential = 1;  seq_iv = DecSeqDetectZ(cfg,P);
+
+verifyEqual(testCase,seq_iv.tstart,expected_iv.tstart,'Double skip NaN sequence start times incorrect');
+verifyEqual(testCase,seq_iv.tend,expected_iv.tend,'Double skip NaN sequence end times incorrect');
+
+% check that double skip works
+expected_iv.tstart = 1; expected_iv.tend = 11;
+
+cfg = []; cfg.nMaxNanSkipSequential = 2;  seq_iv = DecSeqDetectZ(cfg,P);
+
+verifyEqual(testCase,seq_iv.tstart,expected_iv.tstart,'Double 2skip NaN sequence start times incorrect');
+verifyEqual(testCase,seq_iv.tend,expected_iv.tend,'Double 2skip NaN sequence end times incorrect');
+
+% double skip followed by jump
+P.data(:,8) = 0; P.data(50,8) = 1; 
+expected_iv.tstart = [1; 9]; expected_iv.tend = [5; 11];
+
+cfg = []; cfg.nMaxNanSkipSequential = 2;  seq_iv = DecSeqDetectZ(cfg,P);
+
+verifyEqual(testCase,seq_iv.tstart,expected_iv.tstart,'Double 2skipjump NaN sequence start times incorrect');
+verifyEqual(testCase,seq_iv.tend,expected_iv.tend,'Double 2skipjump NaN sequence end times incorrect');
+
 end
 
 
@@ -75,9 +129,9 @@ seq_iv_gap1nan = DecSeqDetectZ(cfg,P); nSeq_gap1nan = length(seq_iv_gap1nan.tsta
 
 % check if any starts or ends are NaN
 seq_start = P.data(1,seq_iv_gap1nan.tstart);
-verifyFalse(testCase,any(isnan(seq_start))),'At least one 1-skip sequence starts with NaN');
+verifyFalse(testCase,any(isnan(seq_start)),'At least one 1-skip sequence starts with NaN');
 seq_end = P.data(1,seq_iv_gap1nan.tend);
-verifyFalse(testCase,any(isnan(seq_end))),'At least one 1-skip sequence ends with NaN');
+verifyFalse(testCase,any(isnan(seq_end)),'At least one 1-skip sequence ends with NaN');
 
 % run no gaps allowed on NaN data
 cfg.nMaxNanSkipSequential = 0;
@@ -111,6 +165,7 @@ fprintf('\nStarting tests...\n');
 %runtests()
 
 end
+
 
 function teardownOnce(testCase)
 

--- a/code-matlab/shared/tests/TEST_DecSeqDetectZ.m
+++ b/code-matlab/shared/tests/TEST_DecSeqDetectZ.m
@@ -73,10 +73,22 @@ P.data(:,nanIdx) = NaN;
 
 seq_iv_gap1nan = DecSeqDetectZ(cfg,P); nSeq_gap1nan = length(seq_iv_gap1nan.tstart);
 
+% check if any starts or ends are NaN
+seq_start = P.data(1,seq_iv_gap1nan.tend);
+verifyFalse(testCase,any(isnan(seq_start)),'At least one 1-skip sequence starts with NaN');
+seq_end = P.data(1,seq_iv_gap1nan.tend);
+verifyFalse(testCase,any(isnan(seq_end)),'At least one 1-skip sequence ends with NaN');
+
 % run no gaps allowed on NaN data
 cfg.nMaxNanSkipSequential = 0;
 seq_iv_gap0nan = DecSeqDetectZ(cfg,P); nSeq_gap0nan = length(seq_iv_gap0nan.tstart);
 verifyLessThan(testCase,nSeq_gap0nan,nSeq_gap1nan,'Seq counts on NaN data not less for no-gap-allowed detection');
+
+% check if any starts or ends are NaN
+seq_start = P.data(1,seq_iv_gap0nan.tend);
+verifyFalse(testCase,any(isnan(seq_start)),'At least one 0-skip sequence starts with NaN');
+seq_end = P.data(1,seq_iv_gap0nan.tend);
+verifyFalse(testCase,any(isnan(seq_end)),'At least one 0-skip sequence ends with NaN');
 
 % verify lengths
 len = seq_iv_nogap.tend-seq_iv_nogap.tstart + 1;

--- a/code-matlab/shared/tests/TEST_DecSeqDetectZ.m
+++ b/code-matlab/shared/tests/TEST_DecSeqDetectZ.m
@@ -6,9 +6,9 @@ tests = functiontests(localfunctions);
 end
 
 
-function testFindSingleSequence(testCase)
+function testFindDefinedSequences(testCase)
 
-% construct test sequence
+% construct single test sequence; easiest case
 nBins = 100;
 
 testSeqData = 1:11; % bins that will be set to 1
@@ -30,37 +30,64 @@ expected_iv.tstart = 1; expected_iv.tend = 11;
 cfg = [];
 seq_iv = DecSeqDetectZ(cfg,P);
 
-verifyEqual(testCase,seq_iv.tstart,expected_iv.tstart,'Start times not equal');
-verifyEqual(testCase,seq_iv.tend,expected_iv.tend,'End times not equal');
+verifyEqual(testCase,seq_iv.tstart,expected_iv.tstart,'Single sequence start time incorrect');
+verifyEqual(testCase,seq_iv.tend,expected_iv.tend,'Single sequence end time incorrect');
 end
 
 
-function testFindSingleSequence(testCase)
+function testFindRandomSequences(testCase)
 
 % construct test sequence
 nBins = 100;
+nPoints = 1e5;
 
-testSeqData = 1:11; % bins that will be set to 1
-testSeqT = 1:11;
+rng('default');
+testSeqData = randi(nBins,[1 nPoints]); % for each column, find bin that will be set to 1
+testSeqIdx = ((0:nPoints-1)*nBins); % create index vector to set zero matrix elements to 1
+testSeqIdx = testSeqIdx + testSeqData;
+
+testSeqT = 1:nPoints;
 
 P = tsd;
-P.data = zeros(nBins,length(testSeqT));
-
-for iT = 1:length(testSeqT)
-    P.data(testSeqData(iT),testSeqT(iT)) = 1;
-end
+P.data = zeros(nBins,nPoints);
+P.data(testSeqIdx) = 1;
 P.tvec = testSeqT;
 
-% expected outcome
-expected_iv = iv;
-expected_iv.tstart = 1; expected_iv.tend = 11;
-
-% run sequence detection
+% run sequence detection -- first without NaN skips selected
 cfg = [];
-seq_iv = DecSeqDetectZ(cfg,P);
+cfg.nMaxNanSkipSequential = 0;
+cfg.minLength = 3;
+seq_iv_nogap = DecSeqDetectZ(cfg,P); nSeq_nogap = length(seq_iv_nogap.tstart);
+verifyGreaterThan(testCase,nSeq_nogap,0,'Number of detected sequences not greater than zero!');
 
-verifyEqual(testCase,seq_iv.tstart,expected_iv.tstart,'Start times not equal');
-verifyEqual(testCase,seq_iv.tend,expected_iv.tend,'End times not equal');
+% now with NaN skips selected
+cfg.nMaxNanSkipSequential = 1;
+seq_iv_gap1 = DecSeqDetectZ(cfg,P); nSeq_gap1 = length(seq_iv_gap1.tstart);
+
+% #seqs for above 2 runs should be the same, because no NaNs in the data!
+verifyEqual(testCase,nSeq_nogap,nSeq_gap1,'Gap and no-gap seq counts on non-NaN data not equal');
+
+% now introduce some NaNs
+nanIdx = randi(nPoints,[1 floor(nPoints./10)]); % find column idxs that will be set to NaN
+P.data(:,nanIdx) = NaN;
+
+seq_iv_gap1nan = DecSeqDetectZ(cfg,P); nSeq_gap1nan = length(seq_iv_gap1nan.tstart);
+
+% run no gaps allowed on NaN data
+cfg.nMaxNanSkipSequential = 0;
+seq_iv_gap0nan = DecSeqDetectZ(cfg,P); nSeq_gap0nan = length(seq_iv_gap0nan.tstart);
+verifyLessThan(testCase,nSeq_gap0nan,nSeq_gap1nan,'Seq counts on NaN data not less for no-gap-allowed detection');
+
+% verify lengths
+len = seq_iv_nogap.tend-seq_iv_nogap.tstart + 1;
+verifyEqual(testCase,cfg.minLength,min(len),sprintf('Smallest 0-skip seq (%d) detected on non-NaN random data not equal to cfg.minLength',min(len)));
+len = seq_iv_gap1.tend-seq_iv_gap1.tstart + 1;
+verifyEqual(testCase,cfg.minLength,min(len),sprintf('Smallest 1-skip seq (%d) detected non-NaN random data not equal to cfg.minLength',min(len)));
+len = seq_iv_gap1nan.tend-seq_iv_gap1nan.tstart + 1;
+verifyEqual(testCase,cfg.minLength,min(len),sprintf('Smallest 1-skip seq (%d) detected on 10%% NaN random data not equal to cfg.minLength',min(len)));
+len = seq_iv_gap0nan.tend-seq_iv_gap0nan.tstart + 1;
+verifyEqual(testCase,cfg.minLength,min(len),sprintf('Smallest 0-skip seq (%d) detected on 10%% NaN random data not equal to cfg.minLength',min(len)));
+
 end
 
 

--- a/code-matlab/shared/tests/TEST_DecSeqDetectZ.m
+++ b/code-matlab/shared/tests/TEST_DecSeqDetectZ.m
@@ -1,0 +1,80 @@
+function tests = DecSeqDetectZTest
+% tests for DecSeqDetectZ() using MATLAB's unit testing framework
+
+tests = functiontests(localfunctions);
+
+end
+
+
+function testFindSingleSequence(testCase)
+
+% construct test sequence
+nBins = 100;
+
+testSeqData = 1:11; % bins that will be set to 1
+testSeqT = 1:11;
+
+P = tsd;
+P.data = zeros(nBins,length(testSeqT));
+
+for iT = 1:length(testSeqT)
+    P.data(testSeqData(iT),testSeqT(iT)) = 1;
+end
+P.tvec = testSeqT;
+
+% expected outcome
+expected_iv = iv;
+expected_iv.tstart = 1; expected_iv.tend = 11;
+
+% run sequence detection
+cfg = [];
+seq_iv = DecSeqDetectZ(cfg,P);
+
+verifyEqual(testCase,seq_iv.tstart,expected_iv.tstart,'Start times not equal');
+verifyEqual(testCase,seq_iv.tend,expected_iv.tend,'End times not equal');
+end
+
+
+function testFindSingleSequence(testCase)
+
+% construct test sequence
+nBins = 100;
+
+testSeqData = 1:11; % bins that will be set to 1
+testSeqT = 1:11;
+
+P = tsd;
+P.data = zeros(nBins,length(testSeqT));
+
+for iT = 1:length(testSeqT)
+    P.data(testSeqData(iT),testSeqT(iT)) = 1;
+end
+P.tvec = testSeqT;
+
+% expected outcome
+expected_iv = iv;
+expected_iv.tstart = 1; expected_iv.tend = 11;
+
+% run sequence detection
+cfg = [];
+seq_iv = DecSeqDetectZ(cfg,P);
+
+verifyEqual(testCase,seq_iv.tstart,expected_iv.tstart,'Start times not equal');
+verifyEqual(testCase,seq_iv.tend,expected_iv.tend,'End times not equal');
+end
+
+
+function setupOnce(testCase)
+
+fprintf('\nStarting tests...\n');
+%warning('off','MATLAB:dispatcher:nameConflict'); % this doesn't get rid of
+%path warning -- seems path is set before setupOnce is being called by
+%runtests()
+
+end
+
+function teardownOnce(testCase)
+
+fprintf('\nAll done!\n');
+
+end

--- a/code-matlab/shared/tests/TEST_DecSeqDetectZ.m
+++ b/code-matlab/shared/tests/TEST_DecSeqDetectZ.m
@@ -74,10 +74,10 @@ P.data(:,nanIdx) = NaN;
 seq_iv_gap1nan = DecSeqDetectZ(cfg,P); nSeq_gap1nan = length(seq_iv_gap1nan.tstart);
 
 % check if any starts or ends are NaN
-seq_start = P.data(1,seq_iv_gap1nan.tend);
-verifyFalse(testCase,any(isnan(seq_start)),'At least one 1-skip sequence starts with NaN');
+seq_start = P.data(1,seq_iv_gap1nan.tstart);
+verifyFalse(testCase,any(isnan(seq_start))),'At least one 1-skip sequence starts with NaN');
 seq_end = P.data(1,seq_iv_gap1nan.tend);
-verifyFalse(testCase,any(isnan(seq_end)),'At least one 1-skip sequence ends with NaN');
+verifyFalse(testCase,any(isnan(seq_end))),'At least one 1-skip sequence ends with NaN');
 
 % run no gaps allowed on NaN data
 cfg.nMaxNanSkipSequential = 0;


### PR DESCRIPTION
## Description

The previous version of `DecSeqDetectZ()` was limited to detecting sequences that contained no NaNs ("skips"), and had no associated tests. This pull request implements configurable NaN-skip functionality. For compatibility with the previous version, the default is to allow no skips. However, other changes, detailed below, result in different output for this new version. A series of tests for `DecSeqDetectZ()` is provided using the [MATLAB testing framework](https://www.mathworks.com/help/matlab/matlab-unit-test-framework.html); to run, use `t = runtests('TEST_DecSeqDetectZ')`.

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ - ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ - ] This change requires a documentation update

Bug fix: previous version contained a "fencepost error" in which the maximum jump allowed was one less than `cfg.maxJump`. This fix can cause the number of detected sequences to differ!

New feature: `cfg.nMaxNanSkipSequential` and `cfg.nMaxNanSkipTotal`cfg options to enable skips in detected sequences. 

## How Has This Been Tested?

Several test cases are now implemented in `TEST_DecSeqDetectZ`, including specific defined sequences, and a long tsd of random data. All tests pass. Future work can expand the suite of tests for this function.

## Checklist:

- [ x ] My code follows vandermeerlab style guidelines
- [ x ] I have performed a self-review of my own code
- [ x ] I have made corresponding changes to the documentation (pretty minimal though, but present)
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ n/a ] Any dependent changes have been merged and published in downstream modules