### PR TITLE
MClust 3.5 fix

### DIFF
--- a/code-matlab/toolboxes/MClust-3.5/ClusterQuality/Create_CQ_File.m
+++ b/code-matlab/toolboxes/MClust-3.5/ClusterQuality/Create_CQ_File.m
@@ -213,8 +213,21 @@ for iFC = 1:length(fc)
 						xrange(:,it) = (((nWVSamples + 2) * (it-1)) + (1:nWVSamples))';
 					end
 					save(fc_WV,'mWV','sWV','xrange','-mat');
-				end
+                end
 				
+                %-------------------------------------------------------------
+				% Save all waveforms if required
+                if exist('allwaveforms', 'var')
+                    switch allwaveforms
+                        case 1
+                        fc_aWV = [Name.Location Name.SessionID '-TT' Name.Tetrode '-' Name.Cluster '-awv.mat'];
+                        if ~exist(fc_aWV,'file')
+                            disp(' Saving all waveforms')
+                            save(fc_aWV,'WV','-mat');
+                        end
+                    end
+                end
+                
 				%-------------------------------------------------------------
 				% Signal to noise ratio calculation
 				disp('  Calculating signal-to-noise ratio')

--- a/code-matlab/toolboxes/MClust-3.5/ClusterQuality/Create_CQ_File.m
+++ b/code-matlab/toolboxes/MClust-3.5/ClusterQuality/Create_CQ_File.m
@@ -223,7 +223,8 @@ for iFC = 1:length(fc)
                         fc_aWV = [Name.Location Name.SessionID '-TT' Name.Tetrode '-' Name.Cluster '-awv.mat'];
                         if ~exist(fc_aWV,'file')
                             disp(' Saving all waveforms')
-                            save(fc_aWV,'WV','-mat');
+                            save(fc_aWV,'WV','T','-mat');
+                        [t,~] = MClust_LoadNeuralData(fc_TT{1},f,2);
                         end
                     end
                 end

--- a/code-matlab/toolboxes/MClust-3.5/ClusterQuality/Create_FeatureSpace.m
+++ b/code-matlab/toolboxes/MClust-3.5/ClusterQuality/Create_FeatureSpace.m
@@ -39,8 +39,10 @@ for iCh = 1:nCh
     nan_idx = isnan(w);
     w(nan_idx) = 0;
     
-    [pc,wpc,variances,t2] = princomp(w);
     
+%     [pc,wpc,variances,t2] = princomp(w);
+% princomp is discontinued, use pca: https://www.mathworks.com/matlabcentral/answers/447831-princomp-has-been-removed-use-pca-instead
+    [pc,wpc,variances,t2] = pca(w);
     % Get the first principal component coefficients for each spike
     Fet(:,iCh + 4) = wpc(:,1);
 end

--- a/code-matlab/toolboxes/MClust-3.5/ClusterQuality/FindNameInfo.m
+++ b/code-matlab/toolboxes/MClust-3.5/ClusterQuality/FindNameInfo.m
@@ -1,4 +1,4 @@
-function NameInfo = FindNameInfo(filename)
+function NameInfo = FindNameInfo(filename, species)
 
 % NameInfo = FindNameInfo(filename);
 %
@@ -7,7 +7,8 @@ function NameInfo = FindNameInfo(filename)
 % the tetrode and cluster number if available.
 %
 % INPUTS: filename: expects a name including a path, unless the name is in the format RXXX-YYYY-MM-DD-TTtt-cc.*
-%                   expects rat ID in RXXX, session date in YYYY-MM-DD
+%                   expects rat ID in RXXX, session date in YYYY-MM-DD or a
+%                   mouse ID in MXXX, session date in YYYY-MM-DD
 %
 % OUTPUTS: NameInfo.RatID = rat's identification number
 %          NameInfo.FileName = original filename passed in
@@ -30,6 +31,7 @@ Tetrode = [];
 Cluster = [];
 Location = [];
 TetrodePrefix = [];
+Species = species;
 
 % Initialize output variable 
 NameInfo.FileName = filename;
@@ -68,15 +70,15 @@ end
 
 Location = p;
 
-Rs = findstr(p,'R');
+Rs = findstr(n,Species);
 if ~isempty(Rs)
-    RatID = p(Rs(end):Rs(end) + 3);
-    SessionID = p(Rs(end):Rs(end) + 14);
+    RatID = n(Rs(end):Rs(end) + 3);
+    SessionID = n(Rs(end):Rs(end) + 14);
 else
-    Rs = findstr(n,'R');
+    Rs = findstr(p,Species);
     if ~isempty(Rs)
-        RatID = n(Rs(end):Rs(end) + 3);
-        SessionID = n(Rs(end):Rs(end) + 14);
+        RatID = p(Rs(end):Rs(end) + 3);
+        SessionID = p(Rs(end):Rs(end) + 14);
     end
 end
 

--- a/code-matlab/toolboxes/MClust-3.5/Utilities/IOUtils/LoadSpikes.m
+++ b/code-matlab/toolboxes/MClust-3.5/Utilities/IOUtils/LoadSpikes.m
@@ -47,8 +47,19 @@ for iF = 1:nFiles
 			warning([ 'Could not open tfile ' tfn]);
 		end
 		
-		ReadHeader(tfp);    
-		S{iF} = fread(tfp,inf,'uint32');	%read as 32 bit ints
+		ReadHeader(tfp);
+        if exist('encoding','var')
+            switch (encoding)
+                case '32'
+                    S{iF} = fread(tfp,inf,'uint32');    % read as 32 bits
+                case '64'
+                    S{iF} = fread(tfp,inf,'uint64');    % read as 64 bits
+            end 
+        else
+            S{iF} = fread(tfp,inf,'uint32');	% default is 32 bits
+        end
+
+		
 		
 		% Set appropriate time units.
 		switch (tsflag)


### PR DESCRIPTION
Allow MCLust to work with 64 bit encoded .t files, M* type folders and an option to save all waveforms 